### PR TITLE
Fix inventory store on disk for share

### DIFF
--- a/example_java/src/main/AndroidManifest.xml
+++ b/example_java/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.flyve.example_java">
 
+    <!-- Allows for storing and retrieving screenshots -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/example_java/src/main/java/org/flyve/example_java/MainActivity.java
+++ b/example_java/src/main/java/org/flyve/example_java/MainActivity.java
@@ -1,5 +1,7 @@
 package org.flyve.example_java;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -12,6 +14,7 @@ import org.flyve.inventory.InventoryTask;
 public class MainActivity extends AppCompatActivity {
 
     private static final String TAG = "inventory.example";
+    private InventoryTask inventoryTask;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -22,11 +25,12 @@ public class MainActivity extends AppCompatActivity {
         btnRun.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                InventoryTask inventoryTask = new InventoryTask(MainActivity.this, "example-app-java");
+                inventoryTask = new InventoryTask(MainActivity.this, "example-app-java", true);
                 inventoryTask.getXML(new InventoryTask.OnTaskCompleted() {
                     @Override
                     public void onTaskSuccess(String data) {
                         Log.d(TAG, data);
+                        share(MainActivity.this, data, 0);
                         Toast.makeText(MainActivity.this, "Inventory Success, check the log", Toast.LENGTH_SHORT).show();
                     }
 
@@ -39,4 +43,19 @@ public class MainActivity extends AppCompatActivity {
             }
         });
     }
+
+    public void share(Context context, String message, int type){
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, message);
+
+        if(type==1) {
+            intent.putExtra(Intent.EXTRA_STREAM, inventoryTask.getCacheFilePath("json"));
+        } else {
+            intent.putExtra(Intent.EXTRA_STREAM, inventoryTask.getCacheFilePath("xml"));
+        }
+
+        context.startActivity(Intent.createChooser(intent, "Share your inventory"));
+    }
+
 }

--- a/inventory/build.gradle
+++ b/inventory/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     })
     testCompile 'junit:junit:4.12'
     testCompile 'com.android.support.test:runner:1.0.1'
+    compile 'com.orhanobut:logger:2.1.1'
 }
 
 Properties properties = new Properties()

--- a/inventory/src/main/java/org/flyve/inventory/FILog.java
+++ b/inventory/src/main/java/org/flyve/inventory/FILog.java
@@ -34,63 +34,90 @@ package org.flyve.inventory;
 
 import android.util.Log;
 
+import com.orhanobut.logger.Logger;
+
 /**
  * This is a Utils class grapper for Log
  */
 public final class FILog {
 
     // This is the tag to search on console
-    static final String TAGLOG = "FlyveMDMInventory";
+    static final String TAG = "InventoryLibrary";
 
-    // private constructor to prevent instance of this class
+    /**
+     * private constructor to prevent instances of this class
+     */
     private FILog() {
     }
 
     /**
-     * Create a log for debug
-     * @param msg String message
+     * Sends a DEBUG log message
+     * @param message to log
      */
-    public static void d(String msg) {
-        if(msg == null) {
-            return;
+    public static void d(String message) {
+        if(message != null) {
+            Logger.d(TAG, message);
         }
-
-        Log.d(TAGLOG, msg);
     }
 
     /**
-     * Create a log for error
-     * @param msg String message
+     * Sends a VERBOSE log message
+     * @param message to log
      */
-    public static void e(String msg) {
-        if(msg == null) {
-            return;
+    public static void v(String message) {
+        if(message != null) {
+            Logger.v(TAG, message);
         }
-
-        Log.e(TAGLOG, msg);
     }
 
     /**
-     * Create a log for information
-     * @param msg String message
+     * Sends an INFO log message
+     * @param message to log
      */
-    public static void i(String msg) {
-        if(msg == null) {
-            return;
+    public static void i(String message) {
+        if(message != null) {
+            Logger.i(TAG, message);
         }
-        Log.i(TAGLOG, msg);
     }
 
     /**
-     * Create a log for verbose
-     * @param msg String message
+     * Sends an ERROR log message
+     * @param message to log
      */
-    public static void v(String msg) {
-        if(msg == null) {
-            return;
+    public static void e(String message) {
+        if(message != null) {
+            Logger.e(TAG, message);
         }
-
-        Log.v(TAGLOG, msg);
     }
 
+    /**
+     * Sends a WARN log message
+     * @param message to log
+     */
+    public static void w(String message) {
+        if(message != null) {
+            Logger.w(TAG, message);
+        }
+    }
+
+    /**
+     * Reports a condition that should never happen, wts (What a Terrible Failure)
+     * @param message to log
+     */
+    public static void wtf(String message) {
+        if(message != null) {
+            Logger.wtf(TAG, message);
+        }
+    }
+
+    /**
+     * Sends a low level calling log
+     * @param obj the name of the class
+     * @param msg the log message
+     * @param level the priority/type of the log message
+     */
+    public static void log(Object obj, String msg, int level) {
+        String final_msg = String.format("[%s] %s", obj.getClass().getName(), msg);
+        Log.println(level, "InventoryAgent", final_msg);
+    }
 }

--- a/inventory/src/main/java/org/flyve/inventory/FlyveException.java
+++ b/inventory/src/main/java/org/flyve/inventory/FlyveException.java
@@ -40,8 +40,8 @@ public class FlyveException extends Exception
 
     /**
      * The superclass constructor with a matching argument is called
-     * @param string message
-     * @param throwable cause
+     * @param message
+     * @param cause
      */
     public FlyveException(String message, Throwable cause)
     {

--- a/inventory/src/main/java/org/flyve/inventory/InventoryTask.java
+++ b/inventory/src/main/java/org/flyve/inventory/InventoryTask.java
@@ -37,6 +37,11 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import com.orhanobut.logger.AndroidLogAdapter;
+import com.orhanobut.logger.FormatStrategy;
+import com.orhanobut.logger.Logger;
+import com.orhanobut.logger.PrettyFormatStrategy;
+
 import org.flyve.inventory.categories.Categories;
 
 import java.lang.reflect.Constructor;
@@ -77,6 +82,14 @@ public class InventoryTask {
     public InventoryTask(Context context, String appVersion) {
         this.appVersion = appVersion;
         ctx = context;
+
+        try {
+            FormatStrategy formatStrategy = PrettyFormatStrategy.newBuilder()
+                    .build();
+            Logger.addLogAdapter(new AndroidLogAdapter(formatStrategy));
+        } catch (Exception ex) {
+            ex.getStackTrace();
+        }
     }
 
     /**
@@ -167,7 +180,7 @@ public class InventoryTask {
                     final String xml = Utils.createXML(ctx, mContent, InventoryTask.this.appVersion);
 
                     if(storeResult) {
-                        Utils.storeFile(xml, fileNameXML);
+                        Utils.storeFile(ctx, xml, fileNameXML);
                     }
 
                     InventoryTask.runOnUI(new Runnable() {
@@ -207,7 +220,7 @@ public class InventoryTask {
                     final String xml = Utils.createXMLWithoutPrivateData(ctx, mContent, InventoryTask.this.appVersion);
 
                     if(storeResult) {
-                        Utils.storeFile(xml, fileNameXML);
+                        Utils.storeFile(ctx, xml, fileNameXML);
                     }
 
                     InventoryTask.runOnUI(new Runnable() {
@@ -247,7 +260,7 @@ public class InventoryTask {
                     final String json = Utils.createJSON(ctx, mContent, InventoryTask.this.appVersion);
 
                     if(storeResult) {
-                        Utils.storeFile(json, fileNameJSON);
+                        Utils.storeFile(ctx, json, fileNameJSON);
                     }
 
                     InventoryTask.runOnUI(new Runnable() {
@@ -286,7 +299,7 @@ public class InventoryTask {
                     final String json = Utils.createJSONWithoutPrivateData(ctx, mContent, InventoryTask.this.appVersion);
 
                     if(storeResult) {
-                        Utils.storeFile(json, fileNameJSON);
+                        Utils.storeFile(ctx, json, fileNameJSON);
                     }
 
                     InventoryTask.runOnUI(new Runnable() {
@@ -318,7 +331,7 @@ public class InventoryTask {
             String json = Utils.createJSON(ctx, mContent, InventoryTask.this.appVersion);
 
             if(storeResult) {
-                Utils.storeFile(json, fileNameJSON);
+                Utils.storeFile(ctx, json, fileNameJSON);
             }
 
             return json;
@@ -338,7 +351,7 @@ public class InventoryTask {
             String xml = Utils.createXML(ctx, mContent, InventoryTask.this.appVersion);
 
             if(storeResult) {
-                Utils.storeFile(xml, fileNameXML);
+                Utils.storeFile(ctx, xml, fileNameXML);
             }
 
             return xml;
@@ -347,6 +360,16 @@ public class InventoryTask {
             Log.e("Library Exception", ex.getLocalizedMessage());
             return null;
         }
+    }
+
+    public String getCacheFilePath(String type) {
+        String path = ctx.getCacheDir().getAbsolutePath() + "/";
+        if(type.equalsIgnoreCase("json")) {
+            path = path + fileNameXML;
+        } else if(type.equalsIgnoreCase("xml"))  {
+            path = path + fileNameJSON;
+        }
+        return path;
     }
 
     /**

--- a/inventory/src/main/java/org/flyve/inventory/Utils.java
+++ b/inventory/src/main/java/org/flyve/inventory/Utils.java
@@ -402,33 +402,54 @@ public class Utils {
         return "";
     }
 
+    /* Checks if external storage is available for read and write */
+    private static boolean isExternalStorageWritable() {
+        String state = Environment.getExternalStorageState();
+        if (Environment.MEDIA_MOUNTED.equals(state)) {
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Logs the message in a directory
      * @param message the message
      * @param filename name of the file
      */
-    public static void storeFile(String message, String filename) {
-        String state = Environment.getExternalStorageState();
+    public static void storeFile(Context context, String message, String filename) {
 
-        File dir = new File("/sdcard/FlyveMDM");
+        String path = context.getCacheDir().getAbsolutePath();
+        File dir = new File(path);
+
+        String state = Environment.getExternalStorageState();
         if (Environment.MEDIA_MOUNTED.equals(state)) {
+
             if(!dir.exists()) {
-                Log.d("Dir created ", "Dir created ");
-                dir.mkdirs();
+                if(dir.mkdirs()) {
+                    FILog.d("create path");
+                } else {
+                    FILog.e("cannot create path");
+                    return;
+                }
             }
 
-            File logFile = new File("/sdcard/FlyveMDM/" + filename);
+            File logFile = new File(path + "/" + filename);
 
             if (!logFile.exists())  {
                 try  {
-                    Log.d("File created ", "File created ");
-                    logFile.createNewFile();
+                    if(logFile.createNewFile()) {
+                        FILog.d("File created");
+                    } else {
+                        FILog.d("Cannot create file");
+                        return;
+                    }
                 } catch (IOException ex) {
-                    Log.e("Inventory", ex.getMessage());
+                    FILog.e(ex.getMessage());
                 }
             }
 
             FileWriter fw = null;
+
             try {
                 //BufferedWriter for performance, true to set append to file flag
                 fw = new FileWriter(logFile, true);
@@ -439,19 +460,22 @@ public class Utils {
                 buf.flush();
                 buf.close();
                 fw.close();
+                FILog.d("Inventory stored");
             }
             catch (IOException ex) {
-                e(ex.getMessage());
+                FILog.e(ex.getMessage());
             }
             finally {
                 if(fw!=null) {
                     try {
                         fw.close();
                     } catch(Exception ex) {
-                        Log.e("Inventory", ex.getMessage());
+                        FILog.e(ex.getMessage());
                     }
                 }
             }
+        } else {
+            FILog.d("External Storage is not available");
         }
     }
 


### PR DESCRIPTION
## Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [Conventional Commit](https://conventionalcommits.org/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
In the inventory agent when the user tries to share the inventory in many cases (whatsapp, telegram, email) the app says that you cannot attach the file or is not recognized and just send a simple message without information

Issue #
close: https://github.com/flyve-mdm/android-inventory-library/issues/96
ref: https://github.com/flyve-mdm/android-inventory-agent/issues/95

## What is the new behavior?
Now the library store the file in the cache folder of the app with full access to prevent that the app cannot access, in the java example is added a new method with the inventory share code and now the user can share on Telegram, WhatsApp, email or other tools available on the device.

In this PR is added and implemented the logger library too and improve some docs code.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
