### PR TITLE
Set append false on filewriter

### DIFF
--- a/inventory/src/main/java/org/flyve/inventory/Utils.java
+++ b/inventory/src/main/java/org/flyve/inventory/Utils.java
@@ -452,7 +452,7 @@ public class Utils {
 
             try {
                 //BufferedWriter for performance, true to set append to file flag
-                fw = new FileWriter(logFile, true);
+                fw = new FileWriter(logFile, false);
                 BufferedWriter buf = new BufferedWriter(fw);
 
                 buf.write(message);


### PR DESCRIPTION
### Changes description

- set append false on filewriter to prevent add more context to a storage file

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A