### PR TITLE
Fix kernel version value

### DIFF
--- a/inventory/src/main/java/org/flyve/inventory/categories/OperatingSystem.java
+++ b/inventory/src/main/java/org/flyve/inventory/categories/OperatingSystem.java
@@ -180,11 +180,11 @@ public class OperatingSystem extends Categories {
     public static String getKernelVersion() {
         try {
             Process p = Runtime.getRuntime().exec("uname -a");
-            InputStream is = null;
+            InputStream is;
             if (p.waitFor() == 0) {
                 is = p.getInputStream();
             } else {
-                is = p.getErrorStream();
+                return "";
             }
             BufferedReader br = new BufferedReader(new InputStreamReader(is),
                     64);


### PR DESCRIPTION
### Changes description

- remove error message on the kernel version return

this is an example of wrong value:

```
<KERNEL_VERSION>ERROR: Error running exec(). Command: [uname, -a] Working Directory: null Environment: null</KERNEL_VERSION>
```

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A