### PR TITLE
Removed return null in method getCatInfo

### DIFF
--- a/inventory/src/main/java/org/flyve/inventory/Utils.java
+++ b/inventory/src/main/java/org/flyve/inventory/Utils.java
@@ -323,7 +323,7 @@ public class Utils {
         } catch (Exception e) {
             FILog.e(e.getMessage());
         }
-        return null;
+        return "";
     }
 
     public static String getSystemProperty(String type) {

--- a/inventory/src/main/java/org/flyve/inventory/categories/Bios.java
+++ b/inventory/src/main/java/org/flyve/inventory/categories/Bios.java
@@ -108,7 +108,7 @@ public class Bios extends Categories {
 	 */
 	public String getBiosDate() {
 		String dateInfo = Utils.getCatInfo("/sys/devices/virtual/dmi/id/bios_date");
-		return dateInfo != null ? dateInfo : "N/A";
+		return !dateInfo.equals("") ? dateInfo : "N/A";
 	}
 
 	/**
@@ -125,7 +125,7 @@ public class Bios extends Categories {
 	 */
 	public String getBiosVersion() {
 		String dateInfo = Utils.getCatInfo("/sys/devices/virtual/dmi/id/bios_version");
-		return dateInfo != null ? dateInfo : "N/A";
+		return !dateInfo.equals("") ? dateInfo : "N/A";
 	}
 
 	/**
@@ -158,7 +158,7 @@ public class Bios extends Categories {
 	 */
 	public String getMotherBoardSerial() {
 		String dateInfo = Utils.getCatInfo("/sys/devices/virtual/dmi/id/board_serial");
-		return dateInfo != null ? dateInfo : "N/A";
+		return !dateInfo.equals("") ? dateInfo : "N/A";
 	}
 
 	/**

--- a/inventory/src/main/java/org/flyve/inventory/categories/Memory.java
+++ b/inventory/src/main/java/org/flyve/inventory/categories/Memory.java
@@ -122,7 +122,7 @@ public class Memory extends Categories {
 
     private void getRamInfo() {
         String infoCat = Utils.getCatInfo("/sys/bus/platform/drivers/ddr_type/ddr_type");
-        if (infoCat != null) {
+        if (!infoCat.equals("")) {
             splitRamInfo(infoCat);
         } else {
             String infoProp = getRamProp();


### PR DESCRIPTION
Signed-off-by: Ivan Del Pino <idelpino@teclib.com>

### Changes description

Validated return method to getCatInfo, now return empty String instead of null

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ivans51 |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes: https://github.com/flyve-mdm/android-inventory-library/issues/162
Related #N/A
Depends on #N/A