### PR TITLE
Gets model name to set CPU name

### DIFF
--- a/inventory/src/main/java/org/flyve/inventory/categories/Cpus.java
+++ b/inventory/src/main/java/org/flyve/inventory/categories/Cpus.java
@@ -230,30 +230,17 @@ public class Cpus extends Categories {
      */
 
     public String getCpuName() {
-        String cpuName = "N/A";
+        String value = "N/A";
         try {
-            FileReader fr = null;
-            BufferedReader br = null;
-            try {
-                File f = new File(CPUINFO);
-                fr = new FileReader(f);
-                br = new BufferedReader(fr, 8 * 1024);
-                String info = br.readLine();
-                cpuName = info.replaceAll("(.*):\\ (.*)", "$2");
-            } catch (IOException e) {
-                FlyveLog.e(e.getMessage());
-            } finally {
-                if (fr != null) {
-                    fr.close();
-                }
-                if (br != null) {
-                    br.close();
-                }
+            Map<String, String> cpuInfo = Utils.getCatMapInfo("/proc/cpuinfo");
+            String cpuName = Utils.getValueMapInfo(cpuInfo, "model name").trim();
+            if (!"".equals(cpuName)){
+                value = cpuName;
             }
         } catch (Exception ex) {
             FlyveLog.e(FlyveLog.getMessage(context, CommonErrorType.CPU_NAME, ex.getMessage()));
         }
-        return cpuName;
+        return value;
     }
 
     /**


### PR DESCRIPTION
### Changes description

I use the value map used to get cpuinfo, and sets the model name to get the cpu name. Before it only gets the first line of the file. In some phones it returns always 0 and not the name.

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [x] Docs have been added/updated

Closes #213 
