### PR TITLE
Sets autofocus feature as optional

### DIFF
--- a/inventory/src/main/AndroidManifest.xml
+++ b/inventory/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-feature android:name="android.hardware.camera" />
-    <uses-feature android:name="android.hardware.camera.autofocus" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
     <application android:allowBackup="true" android:label="@string/app_name">
     </application>
     <uses-sdk android:minSdkVersion="12" android:targetSdkVersion="15" />


### PR DESCRIPTION
Signed-off-by: Alan Grosz <lalogrosz@gmail.com>

### Changes description

I changed the Manifest file to enable more than 2000 devices because this feature is not optional and is not required