### PR TITLE
compatibility with android api 28

### DIFF
--- a/example_java/build.gradle
+++ b/example_java/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion "28.0.3"
 
 
     defaultConfig {
         applicationId "org.flyve.example_java"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {

--- a/example_java/src/main/AndroidManifest.xml
+++ b/example_java/src/main/AndroidManifest.xml
@@ -7,12 +7,13 @@
     <!-- Allows for storing and retrieving screenshots -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+
 
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:usesCleartextTraffic="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/example_java/src/main/AndroidManifest.xml
+++ b/example_java/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <!-- Allows for storing and retrieving screenshots -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
     <application
         android:allowBackup="true"

--- a/example_java/src/main/java/org/flyve/example_java/MainActivity.java
+++ b/example_java/src/main/java/org/flyve/example_java/MainActivity.java
@@ -63,7 +63,6 @@ public class MainActivity extends AppCompatActivity {
         ActivityCompat.requestPermissions(MainActivity.this,
                 new String[]{
                         Manifest.permission.READ_EXTERNAL_STORAGE,
-                        Manifest.permission.READ_PHONE_STATE,
                         Manifest.permission.WRITE_EXTERNAL_STORAGE,
                         Manifest.permission.CAMERA,
                 },
@@ -116,8 +115,7 @@ public class MainActivity extends AppCompatActivity {
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED
                         && grantResults[1] == PackageManager.PERMISSION_GRANTED
-                        && grantResults[2] == PackageManager.PERMISSION_GRANTED
-                        && grantResults[3] == PackageManager.PERMISSION_GRANTED) {
+                        && grantResults[2] == PackageManager.PERMISSION_GRANTED) {
                 }
             }
         }

--- a/example_java/src/main/java/org/flyve/example_java/MainActivity.java
+++ b/example_java/src/main/java/org/flyve/example_java/MainActivity.java
@@ -63,6 +63,7 @@ public class MainActivity extends AppCompatActivity {
         ActivityCompat.requestPermissions(MainActivity.this,
                 new String[]{
                         Manifest.permission.READ_EXTERNAL_STORAGE,
+                        Manifest.permission.READ_PHONE_STATE,
                         Manifest.permission.WRITE_EXTERNAL_STORAGE,
                         Manifest.permission.CAMERA,
                 },
@@ -115,7 +116,8 @@ public class MainActivity extends AppCompatActivity {
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED
                         && grantResults[1] == PackageManager.PERMISSION_GRANTED
-                        && grantResults[2] == PackageManager.PERMISSION_GRANTED) {
+                        && grantResults[2] == PackageManager.PERMISSION_GRANTED
+                        && grantResults[3] == PackageManager.PERMISSION_GRANTED) {
                 }
             }
         }

--- a/example_kotlin/build.gradle
+++ b/example_kotlin/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion "28.0.3"
 
 
     defaultConfig {
         applicationId "org.flyve.example_kotlin"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -34,7 +34,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {

--- a/example_kotlin/src/main/AndroidManifest.xml
+++ b/example_kotlin/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/inventory/build.gradle
+++ b/inventory/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -31,7 +31,11 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.android.support.test:runner:1.0.1'
     implementation 'com.orhanobut:logger:2.1.1'
+    implementation 'com.android.support:support-compat:28.0.0'
+
+
 }
+
 
 Properties properties = new Properties()
 if(project.rootProject.file('local.properties').exists()) {

--- a/inventory/src/main/AndroidManifest.xml
+++ b/inventory/src/main/AndroidManifest.xml
@@ -13,9 +13,8 @@
     <uses-permission android:name="android.permission.GET_PACKAGE_SIZE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
-    <application android:allowBackup="true" android:label="@string/app_name">
+    <application android:allowBackup="true" android:label="@string/app_name" android:usesCleartextTraffic="true">
     </application>
 </manifest>

--- a/inventory/src/main/java/org/flyve/inventory/Utils.java
+++ b/inventory/src/main/java/org/flyve/inventory/Utils.java
@@ -190,7 +190,7 @@ public class Utils {
             jsonQuery.put("deviceId", getDeviceId());
             TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
             if (telephonyManager != null &&
-                    (context.checkPermission(android.Manifest.permission.READ_PHONE_STATE, android.os.Process.myPid(), android.os.Process.myUid())) == PackageManager.PERMISSION_GRANTED) {
+                    (context.checkPermission(android.Manifest.permission.READ_PHONE_STATE, android.os.Process.myPid(), android.os.Process.myUid()) == PackageManager.PERMISSION_GRANTED)) {
                 jsonQuery.put("IMEI", telephonyManager.getDeviceId());
             }
             jsonQuery.put("content", content);

--- a/inventory/src/main/java/org/flyve/inventory/categories/Bios.java
+++ b/inventory/src/main/java/org/flyve/inventory/categories/Bios.java
@@ -26,8 +26,12 @@
 
 package org.flyve.inventory.categories;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.Build;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
 
 import org.flyve.inventory.CommonErrorType;
 import org.flyve.inventory.FlyveLog;
@@ -205,22 +209,34 @@ public class Bios extends Categories {
 			serial = getSerialFromPrivateAPI();
 
 			if (serial.equals("")) {
-				if (!Build.SERIAL.equals(Build.UNKNOWN)) {
-					// Mother Board Serial Number
-					// Since in 2.3.3 a.k.a gingerbread
-					systemSerialNumber = Build.SERIAL;
-				} else {
 
-					try {
-						serial = this.getSerialNumberFromCpuInfo();
-					} catch (Exception ex) {
-						FlyveLog.e(ex.getMessage());
-					}
+				if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+						ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
+							== PackageManager.PERMISSION_GRANTED) {
+					serial = android.os.Build.getSerial();
+				} else{
+					serial = android.os.Build.SERIAL;
+				}
 
-					if (!serial.equals("") && !serial.equals("0000000000000000")) {
-						systemSerialNumber = serial;
+				if (serial.equals("") || serial.equalsIgnoreCase(android.os.Build.UNKNOWN)) {
+					if (!Build.SERIAL.equals(Build.UNKNOWN)) {
+						// Mother Board Serial Number
+						// Since in 2.3.3 a.k.a gingerbread
+						systemSerialNumber = Build.SERIAL;
+					} else {
+
+						try {
+							serial = this.getSerialNumberFromCpuInfo();
+						} catch (Exception ex) {
+							FlyveLog.e(ex.getMessage());
+						}
+
+						if (!serial.equals("") && !serial.equals("0000000000000000")) {
+							systemSerialNumber = serial;
+						}
 					}
 				}
+
 			} else {
 				systemSerialNumber = serial;
 			}

--- a/inventory/src/main/java/org/flyve/inventory/categories/Bios.java
+++ b/inventory/src/main/java/org/flyve/inventory/categories/Bios.java
@@ -28,6 +28,7 @@ package org.flyve.inventory.categories;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.v4.content.ContextCompat;
@@ -42,6 +43,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.UUID;
 
 /**
  * This class get all the information of the Bios
@@ -60,6 +62,7 @@ public class Bios extends Categories {
 	 */
 	private static final long serialVersionUID = -559572118090134691L;
 	private static final String CPUINFO = "/proc/cpuinfo";
+	private static final String PREF_UNIQUE_ID = "PREF_UNIQUE_ID";
 	private final Context context;
 
 	// <!ELEMENT BIOS (SMODEL, SMANUFACTURER, SSN, BDATE, BVERSION,
@@ -88,7 +91,7 @@ public class Bios extends Categories {
 			c.put("MSN", new CategoryValue(getMotherBoardSerial(), "MSN", "motherBoardSerialNumber"));
 			c.put("SMANUFACTURER", new CategoryValue(getManufacturer(), "SMANUFACTURER", "systemManufacturer"));
 			c.put("SMODEL", new CategoryValue(getModel(), "SMODEL", "systemModel"));
-			c.put("SSN", new CategoryValue(getSystemSerialNumber(), "SSN", "systemSerialNumber"));
+			c.put("SSN", new CategoryValue(getSystemUniqueID(), "SSN", "systemSerialNumber"));
 
 			this.add(c);
 		} catch (Exception ex) {
@@ -194,6 +197,29 @@ public class Bios extends Categories {
 		return !dateInfo.equals("") ? dateInfo : "N/A";
 	}
 
+
+	/**
+	 * Get the System Unique Identifier
+	 * @return string with Unique Identifier
+	 */
+	public String getSystemUniqueID() {
+		String uniqueID;
+
+		SharedPreferences sharedPrefs = context.getSharedPreferences(
+				PREF_UNIQUE_ID, Context.MODE_PRIVATE);
+		uniqueID = sharedPrefs.getString(PREF_UNIQUE_ID, null);
+		if (uniqueID == null) {
+			uniqueID = UUID.randomUUID().toString();
+			SharedPreferences.Editor editor = sharedPrefs.edit();
+			editor.putString(PREF_UNIQUE_ID, uniqueID);
+			editor.apply();
+		}
+
+		return uniqueID;
+
+	}
+
+
 	/**
 	 * Get the System serial number
 	 * @return string with the serial number
@@ -209,7 +235,6 @@ public class Bios extends Categories {
 			serial = getSerialFromPrivateAPI();
 
 			if (serial.equals("")) {
-
 				if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
 						ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
 							== PackageManager.PERMISSION_GRANTED) {

--- a/inventory/src/main/res/raw/specification.dtd
+++ b/inventory/src/main/res/raw/specification.dtd
@@ -1,3 +1,44 @@
+
+Skip to content
+
+    Why GitHub?
+                          
+
+
+                    
+Enterprise
+Explore
+                      
+
+                    
+Marketplace
+Pricing
+                       
+
+
+                        
+
+Sign in
+Sign up
+
+6
+10
+
+    16
+
+flyve-mdm/android-inventory-library
+Code
+Issues 9
+Pull requests 1
+Projects 2
+Security
+Insights
+Join GitHub today
+
+GitHub is home to over 40 million developers working together to host and review code, manage projects, and build software together.
+android-inventory-library/inventory/src/main/res/raw/specification.dtd
+@rafaelje rafaelje test(lint): linting with SonarQube (#9) 701bad2 on 30 Jun 2017
+719 lines (679 sloc) 23.9 KB
 <!DOCTYPE REQUEST
 [
 <!ELEMENT DEVICEID (#PCDATA)>
@@ -717,3 +758,19 @@
     <!-- message type, ie "SNMPQUERY" -->
 <!ELEMENT QUERY (#PCDATA)>
 ]>
+
+    © 2019 GitHub, Inc.
+    Terms
+    Privacy
+    Security
+    Status
+    Help
+
+    Contact GitHub
+    Pricing
+    API
+    Training
+    Blog
+    About
+
+

--- a/inventory/src/main/res/raw/specification.dtd
+++ b/inventory/src/main/res/raw/specification.dtd
@@ -1,31 +1,3 @@
-
-Skip to content
-
-    Why GitHub?
-                          
-
-
-                    
-Enterprise
-Explore
-                      
-
-                    
-Marketplace
-Pricing
-                       
-
-
-                        
-
-Sign in
-Sign up
-
-6
-10
-
-    16
-
 flyve-mdm/android-inventory-library
 Code
 Issues 9
@@ -758,19 +730,3 @@ android-inventory-library/inventory/src/main/res/raw/specification.dtd
     <!-- message type, ie "SNMPQUERY" -->
 <!ELEMENT QUERY (#PCDATA)>
 ]>
-
-    © 2019 GitHub, Inc.
-    Terms
-    Privacy
-    Security
-    Status
-    Help
-
-    Contact GitHub
-    Pricing
-    API
-    Training
-    Blog
-    About
-
-


### PR DESCRIPTION
### Changes description

Change serial number managment
Since API 28 is not possible to get real serial number without pri_app privileges
This PR add method to generate UUID and store it with SharePreference

Allow to use usesCleartextTraffic (for non https url)

TargetSDK bump to 28

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A