### PR TITLE
fix(inventory): catch error when get IMEI

### DIFF
--- a/inventory/src/main/java/org/flyve/inventory/Utils.java
+++ b/inventory/src/main/java/org/flyve/inventory/Utils.java
@@ -194,7 +194,12 @@ public class Utils {
             TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
             if (telephonyManager != null &&
                     (context.checkPermission(android.Manifest.permission.READ_PHONE_STATE, android.os.Process.myPid(), android.os.Process.myUid()) == PackageManager.PERMISSION_GRANTED)) {
-                jsonQuery.put("IMEI", telephonyManager.getDeviceId());
+                //Since Android 10 getDeviceID thrown error
+                try{
+                    jsonQuery.put("IMEI", telephonyManager.getDeviceId());
+                }catch (Exception e){
+                    InventoryLog.e(e.getMessage() + e.getCause());
+                }
             }
             jsonQuery.put("content", content);
 


### PR DESCRIPTION
### Changes description

Since android 10
get device identifier thrown an error

```
getDeviceId: The user 10736 does not meet the requirements to access device identifiers.null
```
This PR fix this

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A