### PR TITLE
fix(lib): Skip software if name is empty

### DIFF
--- a/inventory/src/main/java/org/flyve/inventory/categories/Software.java
+++ b/inventory/src/main/java/org/flyve/inventory/categories/Software.java
@@ -101,7 +101,10 @@ public class Software extends Categories {
                 Category c = new Category("SOFTWARES", "softwares");
 
                 String softwareName = getName(p);
-                if(softwareName.equals("N/A")) continue; // Skip software if name is not available
+
+                if (softwareName.isEmpty() || softwareName.equals("N/A")) {
+                    continue; //if softwareName is empty then continue
+                }
 
                 c.put("NAME", new CategoryValue(softwareName, "NAME", "name"));
                 c.put("COMMENTS", new CategoryValue(getPackage(p), "COMMENTS", "comments"));


### PR DESCRIPTION
### Changes description

Changes description

Skip software if name is empty

Empty name are not allowed from GLPI native Inventory

See :

https://github.com/glpi-project/inventory_format/blob/a2040fb467c80e2de63dec936c3fcca63b767ade/inventory.schema.json#L1685-L1691

Fix https://github.com/flyve-mdm/android-inventory-library/issues/328

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ |1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A