### PR TITLE
Fix(Inventory): offset should be with 4 digit

### DIFF
--- a/inventory/src/androidTest/java/org/flyve/inventory/OperatingSystemTest.java
+++ b/inventory/src/androidTest/java/org/flyve/inventory/OperatingSystemTest.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 
 @RunWith(AndroidJUnit4.class)

--- a/inventory/src/androidTest/java/org/flyve/inventory/OperatingSystemTest.java
+++ b/inventory/src/androidTest/java/org/flyve/inventory/OperatingSystemTest.java
@@ -59,6 +59,13 @@ public class OperatingSystemTest {
     @Test
     public void getCurrentTimezoneOffset() {
         assertNotEquals("", new OperatingSystem(appContext).getCurrentTimezoneOffset());
+
+        OperatingSystem operatingSystem = new OperatingSystem(appContext);
+        String timezoneOffset = operatingSystem.getCurrentTimezoneOffset();
+
+        assertNotNull("Timezone offset should not be null", timezoneOffset);
+        assertNotEquals("Timezone offset should not be empty", "", timezoneOffset);
+        assertTrue("Timezone offset should match the format [+/-]HHMM", timezoneOffset.matches("[+-]\\d{4}"));
     }
 
     @Test

--- a/inventory/src/main/java/org/flyve/inventory/categories/OperatingSystem.java
+++ b/inventory/src/main/java/org/flyve/inventory/categories/OperatingSystem.java
@@ -239,11 +239,10 @@ public class OperatingSystem extends Categories {
             Calendar cal = GregorianCalendar.getInstance(tz);
             int offsetInMillis = tz.getOffset(cal.getTimeInMillis());
 
-            int abs = Math.abs(offsetInMillis / 3600000);
-            int abs1 = Math.abs((offsetInMillis / 60000) % 60);
-            /*String offset = String.format(Locale.getDefault(), "%02d:%02d", abs, abs1);*/
-            String offset = abs + "" + abs1;
-            offset = (offsetInMillis >= 0 ? "+" : "-") + offset;
+            int hours = Math.abs(offsetInMillis / 3600000);  // Heures
+            int minutes = Math.abs((offsetInMillis / 60000) % 60);  // Minutes
+
+            String offset = String.format("%s%02d%02d", (offsetInMillis >= 0 ? "+" : "-"), hours, minutes);
 
             value = offset;
         } catch (Exception ex) {


### PR DESCRIPTION
### Changes description

Prevent this error when `offset` only have 3 digit: 

```
<![CDATA[JSON does not validate. Violations:
"+110" does not match to ^[+-][0-9]{4}$ at #->properties:content->properties:operatingsystem->properties:timezone->properties:offset
]]>
```

see ```inventory_format```

https://github.com/glpi-project/inventory_format/blob/20f5f436120385035c2da84c573d5b0c301f356b/inventory.schema.json#L1435-L1441

Closes #N/A
Related #N/A
Depends on #N/A